### PR TITLE
change Zeit's Now to Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Atmo makes creating mock web services for demos, presentations and experiments r
 - Static assets directory
 - Returns JSON/XML/Text
 - Write custom scripts with JS
-- Deploy with a single click (via Zeit's Now)
+- Deploy with a single click (via Vercel)
 
 ## Download
 


### PR DESCRIPTION
Vercel is the new brand, formerly Zeit Now